### PR TITLE
fix incorrect usage of `emoji/table.json` without aliases

### DIFF
--- a/library.js
+++ b/library.js
@@ -8,10 +8,11 @@ var websockets = module.parent.require('./socket.io/index');
 var async = require('async');
 var emojiParser = require('nodebb-plugin-emoji/build/lib/parse');
 var emojiTable = require('nodebb-plugin-emoji/build/emoji/table.json');
+var emojiAliases = require('nodebb-plugin-emoji/build/emoji/aliases.json');
 var reactions = {};
 
 function parse(name) {
-	return emojiParser.buildEmoji(emojiTable[name], '');
+	return emojiParser.buildEmoji(emojiTable[name] || emojiTable[emojiAliases[name]], '');
 }
 
 reactions.init = function (params, callback) {


### PR DESCRIPTION
There is a bug introduced in commit 7f033d33fea4f6361d1905c9368c2e984dde2a50. When using `emoji/table.json`, you have to consider `emoji/aliases.json` as well, otherwise you'll get such an error in many cases when a user tries to reference an emoji by alias:

```
TypeError: Cannot read property 'image' of undefined
    at Object.exports.buildEmoji (/opt/nodebb/node_modules/nodebb-plugin-emoji/build/lib/parse.js:61:15)
    at parse (/opt/nodebb/node_modules/nodebb-plugin-reactions/library.js:14:21)
```

This PR adds correct usage of aliases based on [this similar code](https://github.com/NodeBB/nodebb-plugin-emoji/blob/master/lib/parse.ts#L153) in `nodebb-plugin-emoji`.

It is tested and deployed in production on [this forum](https://screeps.com/forum/).