### PR TITLE
fix: skip null posts

### DIFF
--- a/library.js
+++ b/library.js
@@ -143,7 +143,9 @@ reactions.getReactions = function (data, callback) {
 		callback(null, data);
 	} else {
 		async.eachSeries(data.posts, function (post, next) {
-
+			if (!post) {
+				return setImmediate(next);
+			}
 			async.series({
 				maximumReactions: function (cb) {
 					meta.settings.get('reactions', function (err, settings) {


### PR DESCRIPTION
fixes a crash
```
 {"error":{},"stack":"TypeError: Cannot read property 'pid' of null\n    at totalReactions (/home/saas/nodebb/node_modules/nodebb-plugin-reactions/library.js:155:32)
```